### PR TITLE
feat: user email removed from account icon tooltip;

### DIFF
--- a/server/views/header/template.njk
+++ b/server/views/header/template.njk
@@ -91,7 +91,7 @@ Component options:
                 <span class="one-login-header__nav__link-content">
                   GOV.UK One Login
                 </span>
-                <span title="{{ params.email }}">
+                <span>
                   {{ littlePersonIcon() }}
                   {{ littlePersonIcon("focus") }}
                 </span>


### PR DESCRIPTION
- VP-743: (Desktop, Mobile, iPad) User email is displayed on hover and is not consistently available to all users (Severity Low);