### PR TITLE
VP-739 : (Desktop, Mobile, iPad) Lack of a clear follow-up action leads to unnecessary re-entry of search query text (Severity Medium)

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
   "low": true,
   "package-manager": "auto",
   "registry": "https://registry.npmjs.org",
-  "allowlist": ["GHSA-h67p-54hq-rp68"]
+  "allowlist": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2660,16 +2660,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2682,20 +2672,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -10796,20 +10772,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -18570,13 +18532,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
       "version": "1.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "track-my-case",
       "version": "0.10.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1069.0",
+        "@aws-sdk/client-secrets-manager": "^3.1070.0",
         "@ministryofjustice/frontend": "^8.0.1",
         "@ministryofjustice/hmpps-auth-clients": "^3.0.0",
         "@ministryofjustice/hmpps-precommit-hooks": "^3.0.1",
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1069.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1069.0.tgz",
-      "integrity": "sha512-+pn0c7gUC8JT+hw0BB3u1EHeXCMViA7OZg/hgLM08QIJVzjRG5V6S+Z4NFc2xxDI1YBmDml7kKm8ttocoSHNYw==",
+      "version": "3.1070.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1070.0.tgz",
+      "integrity": "sha512-5t6TmKsESxrrd6iD1tRXaiQxusjboZa846pLZZUwvt4M2xy3FsHUaQoZ50ZPnSr5DNWJubbrHuB+jKn4LGO1eQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     ]
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1069.0",
+    "@aws-sdk/client-secrets-manager": "^3.1070.0",
     "@ministryofjustice/frontend": "^8.0.1",
     "@ministryofjustice/hmpps-auth-clients": "^3.0.0",
     "@ministryofjustice/hmpps-precommit-hooks": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "uuid": "^14.0.0",
     "protobufjs": "^8.3.0",
     "form-data": "^4.0.6",
-    "@opentelemetry/core": "^2.8.0"
+    "@opentelemetry/core": "^2.8.0",
+    "js-yaml": "^4.2.0"
   }
 }

--- a/server/controllers/court-information-controller.test.ts
+++ b/server/controllers/court-information-controller.test.ts
@@ -112,6 +112,7 @@ describe('court-information-controller', () => {
 
       expect(mockGetCaseDetailsByUrn).not.toHaveBeenCalled()
       expect(res.locals.pageTitle).toBe('Court information - No further court dates')
+      expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
       expect(res.render).toHaveBeenCalledWith('pages/case/court-information-inactive')
     })
 
@@ -129,6 +130,7 @@ describe('court-information-controller', () => {
       await courtInformationController(req, res, next)
 
       expect(res.locals.pageTitle).toBe('Court information - No further court dates')
+      expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
       expect(res.render).toHaveBeenCalledWith('pages/case/court-information-inactive')
     })
 
@@ -147,6 +149,7 @@ describe('court-information-controller', () => {
         expect(mockMapCaseDetailsToHearingSummary).toHaveBeenCalledWith(hearing)
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.locals.pageTitle).toBe('Court information - No hearings allocated')
+        expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
         expect(res.render).toHaveBeenCalledWith('pages/case/court-information-no-hearings-allocated', {
           error: 'No hearings allocated for this case',
         })
@@ -173,6 +176,7 @@ describe('court-information-controller', () => {
         expect(mockMapCaseDetailsToHearingSummary).not.toHaveBeenCalled()
         expect(res.status).toHaveBeenCalledWith(404)
         expect(res.render).toHaveBeenCalledWith('pages/case/court-information-not-found')
+        expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
       },
     )
 
@@ -194,6 +198,7 @@ describe('court-information-controller', () => {
 
         expect(mockMapCaseDetailsToHearingSummary).toHaveBeenCalled()
         expect(res.render).toHaveBeenCalledWith('pages/case/court-information')
+        expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
       },
     )
   })
@@ -233,6 +238,7 @@ describe('court-information-controller', () => {
     expect(mockMapCaseDetailsToHearingSummary).toHaveBeenCalledWith(hearing)
     expect(mockGetCourtUrl).toHaveBeenCalledWith('Southwark Crown Court')
     expect(res.locals.courtUrl).toBe('https://example/court')
+    expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
     expect(res.render).toHaveBeenCalledWith('pages/case/court-information')
   })
 
@@ -301,6 +307,7 @@ describe('court-information-controller', () => {
     await courtInformationController(req, res, next)
 
     expect(res.status).toHaveBeenCalledWith(404)
+    expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
     expect(res.render).toHaveBeenCalledWith('pages/case/court-information-not-found')
   })
 
@@ -350,6 +357,7 @@ describe('court-information-controller', () => {
 
     await courtInformationController(req, res, next)
 
+    expect(res.locals.backLink).toBe(paths.CASES.SEARCH)
     expect(res.redirect).toHaveBeenCalledWith(paths.CASES.SEARCH)
   })
 

--- a/server/controllers/court-information-controller.ts
+++ b/server/controllers/court-information-controller.ts
@@ -66,7 +66,7 @@ const courtInformationController = async (req: Request, res: Response, next: Nex
     await initialiseBasicAuthentication(req, res, next)
 
     res.locals.pageTitle = 'Court information'
-    res.locals.backLink = paths.CASES.DASHBOARD
+    res.locals.backLink = paths.CASES.SEARCH
 
     res.locals.displayHearing = config.featureFlags.displayHearing
 

--- a/server/views/pages/case/court-information-not-found.njk
+++ b/server/views/pages/case/court-information-not-found.njk
@@ -11,6 +11,7 @@
       <p class="govuk-body"><strong>Unique reference number (URN):</strong> {{ selectedUrn }}</p>
       <p class="govuk-body">Check you are using the correct unique reference number (URN) or contact your police witness care unit or police officer in charge.</p>
       <p class="govuk-body">If you need information about a court, use the <a class="govuk-link" href="https://www.find-court-tribunal.service.gov.uk" target="_blank">Find a Court or Tribunal service (opens in new tab)</a>.</p>
+      <a href="/case/search" role="button" id="search-again-button" class="govuk-button govuk-button--primary" draggable="false" data-module="govuk-button">Search again</a>
     </div>
   </div>
 


### PR DESCRIPTION
feat: search again button added on case not found screen;

- VP-739: (Desktop, Mobile, iPad) Lack of a clear follow-up action leads to unnecessary re-entry of search query text (Severity Medium);
- back button url changed to /case/search;