### PR TITLE
feat: enable waf and rate limiting on ingress

### DIFF
--- a/.github/workflows/build-push-deploy-preprod.yml
+++ b/.github/workflows/build-push-deploy-preprod.yml
@@ -236,6 +236,9 @@ jobs:
           --set WebApp.Image.Tag=$NEW_TAG_V \
           --set WebApp.Name=$KUBE_NAMESPACE \
           --set-string WebApp.variables_hash="$variables_hash" \
+          --set Ingress.ModSec.Enabled=true \
+          --set Ingress.ModSec.Class="modsec" \
+          --set Ingress.ModSec.DetectionOnly=true \
           --set securityContext.allowPrivilegeEscalation=false \
           --set securityContext.capabilities.drop=["ALL"] \
           --set securityContext.runAsNonRoot=true \

--- a/.github/workflows/build-push-deploy-prod.yml
+++ b/.github/workflows/build-push-deploy-prod.yml
@@ -225,6 +225,11 @@ jobs:
           --set WebApp.Image.Tag=$NEW_TAG_V \
           --set WebApp.Name=$KUBE_NAMESPACE \
           --set-string WebApp.variables_hash="$variables_hash" \
+          --set Ingress.ModSec.Enabled=true \
+          --set Ingress.ModSec.Class="modsec" \
+          --set Ingress.ModSec.DetectionOnly=true \
+          --set Ingress.rateLimit.rps=50 \
+          --set Ingress.rateLimit.connections=25 \
           --set securityContext.allowPrivilegeEscalation=false \
           --set securityContext.capabilities.drop=["ALL"] \
           --set securityContext.runAsNonRoot=true \

--- a/.github/workflows/build-push-deploy-sit.yml
+++ b/.github/workflows/build-push-deploy-sit.yml
@@ -236,6 +236,7 @@ jobs:
           --set WebApp.Image.Tag=$NEW_TAG_V \
           --set WebApp.Name=$KUBE_NAMESPACE \
           --set-string WebApp.variables_hash="$variables_hash" \
+          --set Ingress.ModSec.Enabled=true \
           --set securityContext.allowPrivilegeEscalation=false \
           --set securityContext.capabilities.drop=["ALL"] \
           --set securityContext.runAsNonRoot=true \

--- a/.github/workflows/build-push-deploy-test.yml
+++ b/.github/workflows/build-push-deploy-test.yml
@@ -236,6 +236,7 @@ jobs:
           --set WebApp.Image.Tag=$NEW_TAG_V \
           --set WebApp.Name=$KUBE_NAMESPACE \
           --set-string WebApp.variables_hash="$variables_hash" \
+          --set Ingress.ModSec.Enabled=true \
           --set securityContext.allowPrivilegeEscalation=false \
           --set securityContext.capabilities.drop=["ALL"] \
           --set securityContext.runAsNonRoot=true \


### PR DESCRIPTION
- enable modsec/waf on nginx ingress
- apply rate limiting for 50 request per ip per second (large number but safer to introduce first and reduce later) 